### PR TITLE
Update pluginInfo.json

### DIFF
--- a/pluginInfo.json
+++ b/pluginInfo.json
@@ -21,7 +21,7 @@
 		},
 		{
 			"minFPPVersion": "5.0",
-			"maxFPPVersion": "0",
+			"maxFPPVersion": "8.99",
 			"branch": "master",
 			"sha": "",
 			"dependencies": {


### PR DESCRIPTION
Due to a lot of Plugin incompatibilities with Version 8 and the Linux distribution, we have to make sure that the plugin specifically states that it is compatible with Version 8.