### PR TITLE
Updates default plugins API path

### DIFF
--- a/js/remote_falcon_core.js
+++ b/js/remote_falcon_core.js
@@ -1,5 +1,5 @@
 //Config Globals
-const DEFAULT_PLUGINS_API_PATH = 'https://remotefalcon.com/remotefalcon/api';
+const DEFAULT_PLUGINS_API_PATH = 'https://remotefalcon.com/remote-falcon-plugins-api';
 
 var PLUGIN_VERSION = null;
 var REMOTE_TOKEN = null;

--- a/remote_falcon_listener.php
+++ b/remote_falcon_listener.php
@@ -1,5 +1,5 @@
 <?php
-$PLUGIN_VERSION = "2025.04.05.1";
+$PLUGIN_VERSION = "2025.06.29.1";
 
 include_once "/opt/fpp/www/common.php";
 $pluginName = basename(dirname(__FILE__));
@@ -30,7 +30,7 @@ if (strlen(urldecode($pluginSettings['fppStatusCheckTime']))<1){
   WriteSettingToFile("fppStatusCheckTime",urlencode("1"),$pluginName);
 }
 if (strlen(urldecode($pluginSettings['pluginsApiPath']))<1){
-  WriteSettingToFile("pluginsApiPath",urlencode("https://remotefalcon.com/remotefalcon/api"),$pluginName);
+  WriteSettingToFile("pluginsApiPath",urlencode("https://remotefalcon.com/remote-falcon-plugins-api"),$pluginName);
 }
 if (strlen(urldecode($pluginSettings['verboseLogging']))<1){
   WriteSettingToFile("verboseLogging",urlencode("false"),$pluginName);

--- a/remote_falcon_ui.html
+++ b/remote_falcon_ui.html
@@ -226,7 +226,7 @@
           <div class="mb-2 text-muted card-subtitle">
             This controls which API is used by the plugin <br />
             <span class="warning">WARNING!</span> <br />
-            This should always be <b>https://remotefalcon.com/remotefalcon/api</b>. <br />
+            This should always be <b>https://remotefalcon.com/remote-falcon-plugins-api</b>. <br />
             Don't change this unless you know what you're doing and/or want to break things.
           </div>
         </div>


### PR DESCRIPTION
Updates the default plugins API path to the new `remote-falcon-plugins-api` endpoint.

This change ensures the plugin uses the correct API for fetching and managing plugins, preventing potential issues with plugin discovery and functionality.