### PR TITLE
fix: Resolve selected playlist bug #99

### DIFF
--- a/js/remote_falcon_core.js
+++ b/js/remote_falcon_core.js
@@ -80,7 +80,7 @@ async function getPluginConfig() {
   // await FPPGet('/api/plugin/remote-falcon/settings/remotePlaylist', (data) => {
   //   REMOTE_PLAYLIST = data?.remotePlaylist;
   // });
-  getRemotePlaylistFromConfig();
+  await getRemotePlaylistFromConfig();
 }
 
 async function getRemotePlaylistFromConfig() {

--- a/remote_falcon_listener.php
+++ b/remote_falcon_listener.php
@@ -1,5 +1,5 @@
 <?php
-$PLUGIN_VERSION = "2025.09.05.1";
+$PLUGIN_VERSION = "2025.09.22.1";
 
 include_once "/opt/fpp/www/common.php";
 $pluginName = basename(dirname(__FILE__));


### PR DESCRIPTION
* The logic to retrieve the current playlist from the config file runs async and without an await may not complete before the logic runs to populate the drop down leaving the default first one selected. Adding an await ensures the logic populates the REMOTE_PLAYLIST variable.